### PR TITLE
fix mint rate order of operations

### DIFF
--- a/script/deploy/DeployVault.s.sol
+++ b/script/deploy/DeployVault.s.sol
@@ -41,7 +41,7 @@ contract DeployVault is Helpers {
             string.concat("p", _underlyingAsset.symbol(), _symbolSuffix, "-T"),
             _yieldVault,
             prizePool,
-            _getClaimer(),
+            address(_getClaimer()),
             msg.sender,
             100000000, // 0.1 = 10%
             msg.sender

--- a/src/PrizeVaultMintRate.sol
+++ b/src/PrizeVaultMintRate.sol
@@ -18,7 +18,7 @@ contract PrizeVaultMintRate is PrizeVault {
         string memory _symbol,
         IERC4626 yieldVault_,
         PrizePool _prizePool,
-        Claimer _claimer,
+        address _claimer,
         address _yieldFeeRecipient,
         uint32 _yieldFeePercentage,
         address _owner
@@ -28,7 +28,7 @@ contract PrizeVaultMintRate is PrizeVault {
             _symbol,
             yieldVault_,
             _prizePool,
-            address(_claimer),
+            _claimer,
             _yieldFeeRecipient,
             _yieldFeePercentage,
             1000,
@@ -39,7 +39,7 @@ contract PrizeVaultMintRate is PrizeVault {
     }
 
     function _mint(address _receiver, uint256 _shares) internal virtual override {
-        YieldVaultMintRate(address(_yieldVault)).mintRate(); // Updates the accrued yield in the YieldVaultMintRate
         super._mint(_receiver, _shares);
+        YieldVaultMintRate(address(_yieldVault)).mintRate(); // Updates the accrued yield in the YieldVaultMintRate
     }
 }

--- a/src/YieldVaultMintRate.sol
+++ b/src/YieldVaultMintRate.sol
@@ -28,29 +28,31 @@ contract YieldVaultMintRate is ERC4626, AccessControl {
 
     /* ============ External Functions ============ */
 
-    function deposit(uint256 assets, address receiver) public virtual override returns (uint256) {
-        _mintRate();
+    function deposit(uint256 assets, address receiver) public virtual override _mintRate returns (uint256) {
         return super.deposit(assets, receiver);
     }
 
-    function mint(uint256 shares, address receiver) public virtual override returns (uint256) {
-        _mintRate();
+    function mint(uint256 shares, address receiver) public virtual override _mintRate returns (uint256) {
         return super.mint(shares, receiver);
     }
 
-    function withdraw(uint256 assets, address receiver, address owner) public virtual override returns (uint256) {
-        _mintRate();
+    function withdraw(
+        uint256 assets,
+        address receiver,
+        address owner
+    ) public virtual override _mintRate returns (uint256) {
         return super.withdraw(assets, receiver, owner);
     }
 
-    function redeem(uint256 shares, address receiver, address owner) public virtual override returns (uint256) {
-        _mintRate();
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner
+    ) public virtual override _mintRate returns (uint256) {
         return super.redeem(shares, receiver, owner);
     }
 
-    function setRatePerSecond(uint256 _ratePerSecond) external onlyMinterRole {
-        _mintRate();
-        lastYieldTimestamp = block.timestamp;
+    function setRatePerSecond(uint256 _ratePerSecond) external onlyMinterRole _mintRate {
         ratePerSecond = _ratePerSecond;
     }
 
@@ -58,16 +60,16 @@ contract YieldVaultMintRate is ERC4626, AccessControl {
         ERC20Mintable(asset()).mint(address(this), amount);
     }
 
-    function mintRate() external onlyMinterRole {
-        _mintRate();
-    }
+    function mintRate() external onlyMinterRole _mintRate {}
 
     /* ============ Internal Functions ============ */
 
-    function _mintRate() internal {
+    modifier _mintRate() {
         uint256 deltaTime = block.timestamp - lastYieldTimestamp;
         uint256 rateMultiplier = deltaTime * ratePerSecond;
         uint256 balance = ERC20Mintable(asset()).balanceOf(address(this));
+
+        _;
 
         ERC20Mintable(asset()).mint(address(this), (rateMultiplier * balance) / 1 ether);
         lastYieldTimestamp = block.timestamp;

--- a/test/integration/PrizeVaultMintRate.t.sol
+++ b/test/integration/PrizeVaultMintRate.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import { IERC20 } from "openzeppelin/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "openzeppelin/mocks/ERC20Mock.sol";
+
+import { IntegrationBaseSetup } from "../utils/IntegrationBaseSetup.t.sol";
+import { Helpers } from "../utils/Helpers.t.sol";
+
+import { YieldVaultMintRate, ERC20Mintable } from "../../src/YieldVaultMintRate.sol";
+import { PrizeVaultMintRate } from "../../src/PrizeVaultMintRate.sol";
+
+contract PrizeVaultMintRateTest is IntegrationBaseSetup, Helpers {
+    YieldVaultMintRate public yieldVaultMintRate;
+    PrizeVaultMintRate public prizeVaultMintRate;
+
+    /* ============ setUp ============ */
+    function setUp() public override {
+        super.setUp();
+
+        yieldVaultMintRate = new YieldVaultMintRate(
+            ERC20Mintable(address(underlyingAsset)),
+            "Yield Vault",
+            "YV",
+            address(this)
+        );
+        yieldVaultMintRate.setRatePerSecond(uint256(250000000000000000) / 365 days); // ~25% APR
+        prizeVaultMintRate = new PrizeVaultMintRate(
+            vaultName,
+            vaultSymbol,
+            yieldVaultMintRate,
+            prizePool,
+            address(claimer),
+            address(this),
+            0, // 0%
+            address(this)
+        );
+        yieldVaultMintRate.grantRole(yieldVaultMintRate.MINTER_ROLE(), address(prizeVaultMintRate));
+    }
+
+    /* ============ Deposit Works ============ */
+
+    function testDepositWorks() public {
+        underlyingAsset.mint(alice, 2e18);
+
+        vm.startPrank(alice);
+
+        underlyingAsset.approve(address(prizeVaultMintRate), 1e18);
+        prizeVaultMintRate.deposit(1e18, alice);
+        assertEq(prizeVaultMintRate.balanceOf(alice), 1e18);
+
+        vm.warp(block.timestamp + 100); // time passes
+
+        underlyingAsset.approve(address(prizeVaultMintRate), 1e18);
+        prizeVaultMintRate.deposit(1e18, alice);
+        assertEq(prizeVaultMintRate.balanceOf(alice), 2e18);
+        assertGt(prizeVaultMintRate.totalAssets(), 2e18);
+
+        vm.stopPrank();
+    }
+}

--- a/test/integration/Withdraw.t.sol
+++ b/test/integration/Withdraw.t.sol
@@ -23,6 +23,10 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         uint256 _amount = 1000e18;
         underlyingAsset.mint(alice, _amount);
 
+        // mint some yield to the vault yield buffer to simulate normal operating conditions
+        uint256 yieldBuffer = vault.yieldBuffer();
+        underlyingAsset.mint(address(vault), yieldBuffer);
+
         _deposit(underlyingAsset, vault, _amount, alice);
         vault.withdraw(vault.maxWithdraw(alice), alice, alice);
 
@@ -32,8 +36,8 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         assertEq(twabController.balanceOf(address(vault), alice), 0);
         assertEq(twabController.delegateBalanceOf(address(vault), alice), 0);
 
-        assertEq(underlyingAsset.balanceOf(address(yieldVault)), 0);
-        assertEq(yieldVault.balanceOf(address(vault)), 0);
+        assertEq(underlyingAsset.balanceOf(address(yieldVault)), yieldBuffer);
+        assertEq(yieldVault.balanceOf(address(vault)), yieldBuffer);
 
         vm.stopPrank();
     }
@@ -45,6 +49,10 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         uint256 _halfAmount = _amount / 2;
         underlyingAsset.mint(alice, _amount);
 
+        // mint some yield to the vault yield buffer to simulate normal operating conditions
+        uint256 yieldBuffer = vault.yieldBuffer();
+        underlyingAsset.mint(address(vault), yieldBuffer);
+
         _deposit(underlyingAsset, vault, _amount, alice);
         vault.withdraw(_halfAmount, alice, alice);
 
@@ -54,8 +62,8 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         assertEq(twabController.balanceOf(address(vault), alice), _halfAmount);
         assertEq(twabController.delegateBalanceOf(address(vault), alice), _halfAmount);
 
-        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _halfAmount);
-        assertEq(yieldVault.balanceOf(address(vault)), _halfAmount);
+        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _halfAmount + yieldBuffer);
+        assertEq(yieldVault.balanceOf(address(vault)), _halfAmount + yieldBuffer);
 
         vm.stopPrank();
     }
@@ -63,6 +71,10 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
     function testWithdrawFullAmountYieldAccrued() external {
         uint256 _amount = 1000e18;
         underlyingAsset.mint(alice, _amount);
+
+        // mint some yield to the vault yield buffer to simulate normal operating conditions
+        uint256 yieldBuffer = vault.yieldBuffer();
+        underlyingAsset.mint(address(vault), yieldBuffer);
 
         vm.startPrank(alice);
 
@@ -83,8 +95,8 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         assertEq(twabController.balanceOf(address(vault), alice), 0);
         assertEq(twabController.delegateBalanceOf(address(vault), alice), 0);
 
-        assertEq(yieldVault.convertToAssets(yieldVault.balanceOf(address(vault))), _yield);
-        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _yield);
+        assertApproxEqAbs(yieldVault.convertToAssets(yieldVault.balanceOf(address(vault))), _yield + yieldBuffer, 1);
+        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _yield + yieldBuffer);
 
         vm.stopPrank();
     }
@@ -96,6 +108,10 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         uint256 _amount = 1000e18;
         underlyingAsset.mint(alice, _amount);
 
+        // mint some yield to the vault yield buffer to simulate normal operating conditions
+        uint256 yieldBuffer = vault.yieldBuffer();
+        underlyingAsset.mint(address(vault), yieldBuffer);
+
         _deposit(underlyingAsset, vault, _amount, alice);
         vault.redeem(vault.maxRedeem(alice), alice, alice);
 
@@ -105,8 +121,8 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         assertEq(twabController.balanceOf(address(vault), alice), 0);
         assertEq(twabController.delegateBalanceOf(address(vault), alice), 0);
 
-        assertEq(underlyingAsset.balanceOf(address(yieldVault)), 0);
-        assertEq(yieldVault.balanceOf(address(vault)), 0);
+        assertEq(underlyingAsset.balanceOf(address(yieldVault)), yieldBuffer);
+        assertEq(yieldVault.balanceOf(address(vault)), yieldBuffer);
 
         vm.stopPrank();
     }
@@ -118,6 +134,10 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         uint256 _halfAmount = _amount / 2;
         underlyingAsset.mint(alice, _amount);
 
+        // mint some yield to the vault yield buffer to simulate normal operating conditions
+        uint256 yieldBuffer = vault.yieldBuffer();
+        underlyingAsset.mint(address(vault), yieldBuffer);
+
         uint256 _shares = _deposit(underlyingAsset, vault, _amount, alice);
         vault.redeem(_shares / 2, alice, alice);
 
@@ -127,8 +147,8 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         assertEq(twabController.balanceOf(address(vault), alice), _halfAmount);
         assertEq(twabController.delegateBalanceOf(address(vault), alice), _halfAmount);
 
-        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _halfAmount);
-        assertEq(yieldVault.balanceOf(address(vault)), _halfAmount);
+        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _halfAmount + yieldBuffer);
+        assertEq(yieldVault.balanceOf(address(vault)), _halfAmount + yieldBuffer);
 
         vm.stopPrank();
     }
@@ -136,6 +156,10 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
     function testRedeemFullAmountYieldAccrued() external {
         uint256 _amount = 1000e18;
         underlyingAsset.mint(alice, _amount);
+
+        // mint some yield to the vault yield buffer to simulate normal operating conditions
+        uint256 yieldBuffer = vault.yieldBuffer();
+        underlyingAsset.mint(address(vault), yieldBuffer);
 
         vm.startPrank(alice);
 
@@ -156,8 +180,8 @@ contract WithdrawIntegrationTest is IntegrationBaseSetup, Helpers {
         assertEq(twabController.balanceOf(address(vault), alice), 0);
         assertEq(twabController.delegateBalanceOf(address(vault), alice), 0);
 
-        assertEq(yieldVault.convertToAssets(yieldVault.balanceOf(address(vault))), _yield, "yield is available");
-        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _yield);
+        assertApproxEqAbs(yieldVault.convertToAssets(yieldVault.balanceOf(address(vault))), _yield + yieldBuffer, 1);
+        assertEq(underlyingAsset.balanceOf(address(yieldVault)), _yield + yieldBuffer);
 
         vm.stopPrank();
     }


### PR DESCRIPTION
This isn't an issue with the Prize Vault since the mint call is guaranteed to use the same or less assets than the deposit call would. Rather, this is an issue with the YieldVaultMintRate contract breaking the ERC4626 spec since it is changing the exchange rate right before the mint happens.

Fixed by calculating the mint rate before any state changes and then performing the actual yield mint after.